### PR TITLE
HC-1128 pin GitHub Actions to commit SHA

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -8,7 +8,7 @@ jobs:
   format-code:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.2.2
-      - uses: ministryofjustice/github-actions/code-formatter@v18.5.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: ministryofjustice/github-actions/code-formatter@ccf9e3a4a828df1ec741f6c8e6ed9d0acaef3490 # v18.5.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tf-static-analysis.yml
+++ b/.github/workflows/tf-static-analysis.yml
@@ -39,12 +39,12 @@ jobs:
         echo "scan=$scan_type_default" >> $GITHUB_ENV
 
     - name: Checkout
-      uses: actions/checkout@v4.2.2
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         fetch-depth: 0
 
     - name: Run Analysis
-      uses: ministryofjustice/github-actions/terraform-static-analysis@v18.5.0
+      uses: ministryofjustice/github-actions/terraform-static-analysis@ccf9e3a4a828df1ec741f6c8e6ed9d0acaef3490 # v18.5.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:


### PR DESCRIPTION
Pin GitHub Actions to the specific full-length commit SHA for the desired version of the action.

As per Slack discussion in [#github-community](https://mojdt.slack.com/archives/C05L0KBA7RS/p1730199255440819)

And this guide: [https://www.stepsecurity.io/blog/pinning-github-actions-for-enhanced-security-a-complete-guide](https://www.stepsecurity.io/blog/pinning-github-actions-for-enhanced-security-a-complete-guide)

_Once a commit SHA is pinned, it guarantees that the specific code version cannot be altered. This offers significant security benefits compared to relying on version tags, which can be changed to point to different code versions._
